### PR TITLE
Improve treatment of package source

### DIFF
--- a/manifests/canbus.pp
+++ b/manifests/canbus.pp
@@ -31,6 +31,8 @@ class ccs_hcu::canbus (
       extract      => true,
       extract_path => '/usr/src',
       source       => "${ccs_hcu::pkgurl}/${src}",
+      username     => $ccs_hcu::pkgurl_user,
+      password     => $ccs_hcu::pkgurl_pass,
       creates      => "/usr/src/${dest}",
       cleanup      => true,
     }

--- a/manifests/canbus.pp
+++ b/manifests/canbus.pp
@@ -20,7 +20,6 @@ class ccs_hcu::canbus (
   if $ensure =~ /(present|absent)/ {
     ensure_packages(['xz', 'tar'])
 
-    $ccs_pkgarchive = lookup('ccs_pkgarchive', String)
     ## Patched version with dkms.conf and fixed driver/Makefile.
     $src = "${module}_V${version}_dkms.tar.xz"
     $lmodule = "${downcase($module)}"
@@ -31,7 +30,7 @@ class ccs_hcu::canbus (
       ensure       => $ensure,
       extract      => true,
       extract_path => '/usr/src',
-      source       => "${ccs_pkgarchive}/${src}",
+      source       => "${ccs_hcu::pkgurl}/${src}",
       creates      => "/usr/src/${dest}",
       cleanup      => true,
     }

--- a/manifests/imanager.pp
+++ b/manifests/imanager.pp
@@ -28,6 +28,8 @@ class ccs_hcu::imanager (
       extract      => true,
       extract_path => '/usr/src',
       source       => "${ccs_hcu::pkgurl}/${src}",
+      username     => $ccs_hcu::pkgurl_user,
+      password     => $ccs_hcu::pkgurl_pass,
       creates      => "/usr/src/${dest}",
       cleanup      => true,
     }

--- a/manifests/imanager.pp
+++ b/manifests/imanager.pp
@@ -18,7 +18,6 @@ class ccs_hcu::imanager (
   if $ensure =~ /(present|absent)/ {
     ensure_packages(['xz', 'tar'])
 
-    $ccs_pkgarchive = lookup('ccs_pkgarchive', String)
     ## Patched version with dkms.conf and fixed Makefile.
     $src = "${module}-${version}_dkms.tar.xz"
     $dest = "${module}-${version}"
@@ -28,7 +27,7 @@ class ccs_hcu::imanager (
       ensure       => $ensure,
       extract      => true,
       extract_path => '/usr/src',
-      source       => "${ccs_pkgarchive}/${src}",
+      source       => "${ccs_hcu::pkgurl}/${src}",
       creates      => "/usr/src/${dest}",
       cleanup      => true,
     }

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -17,7 +17,11 @@
 # @param ft4232h
 #   true or false to enable ft4232h.
 # @param pkgurl
-#   String specifying URL to fetch sources from
+#   String specifying URL to fetch sources from.
+# @param pkgurl_user
+#   String specifying username to access pkgurl.
+# @param pkgurl_pass
+#   String specifying password to access pkgurl.
 #
 class ccs_hcu (
   Boolean $quadbox = false,
@@ -27,6 +31,8 @@ class ccs_hcu (
   Variant[Boolean,String] $filter_changer = false,
   Boolean $ft4232h = false,
   String $pkgurl = 'https://example.org',
+  String $pkgurl_user = 'someuser',
+  String $pkgurl_pass = 'somepass',
 ) {
   $opts0 = {
     'canbus'         => $canbus,

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -16,6 +16,8 @@
 #   True (or 'present') to install; false (or 'absent') to remove.
 # @param ft4232h
 #   true or false to enable ft4232h.
+# @param pkgurl
+#   String specifying URL to fetch sources from
 #
 class ccs_hcu (
   Boolean $quadbox = false,
@@ -24,6 +26,7 @@ class ccs_hcu (
   Variant[Boolean,String] $imanager = false,
   Variant[Boolean,String] $filter_changer = false,
   Boolean $ft4232h = false,
+  String $pkgurl = 'https://example.org',
 ) {
   $opts0 = {
     'canbus'         => $canbus,

--- a/manifests/vldrive.pp
+++ b/manifests/vldrive.pp
@@ -30,6 +30,8 @@ class ccs_hcu::vldrive (
       extract      => true,
       extract_path => '/usr/src',
       source       => "${ccs_hcu::pkgurl}/${src}",
+      username     => $ccs_hcu::pkgurl_user,
+      password     => $ccs_hcu::pkgurl_pass,
       creates      => "/usr/src/${dest}",
       cleanup      => true,
     }

--- a/manifests/vldrive.pp
+++ b/manifests/vldrive.pp
@@ -20,7 +20,6 @@ class ccs_hcu::vldrive (
   if $ensure =~ /(present|absent)/ {
     ensure_packages(['xz', 'tar'])
 
-    $ccs_pkgarchive = lookup('ccs_pkgarchive', String)
     ## Patched version with dkms.conf and dkms_build.sh script.
     $src = "${module}-${version}_dkms.tar.xz"
     $dest = "${module}-${version}"
@@ -30,7 +29,7 @@ class ccs_hcu::vldrive (
       ensure       => $ensure,
       extract      => true,
       extract_path => '/usr/src',
-      source       => "${ccs_pkgarchive}/${src}",
+      source       => "${ccs_hcu::pkgurl}/${src}",
       creates      => "/usr/src/${dest}",
       cleanup      => true,
     }

--- a/spec/fixtures/hieradata/common.yaml
+++ b/spec/fixtures/hieradata/common.yaml
@@ -1,2 +1,2 @@
 ---
-ccs_pkgarchive: "https://example.org"
+ccs_hcu::pkgurl: "https://example.org"

--- a/spec/fixtures/hieradata/common.yaml
+++ b/spec/fixtures/hieradata/common.yaml
@@ -1,2 +1,4 @@
 ---
 ccs_hcu::pkgurl: "https://example.org"
+ccs_hcu::pkgurl_user: "someuser"
+ccs_hcu::pkgurl_pass: "somepass"


### PR DESCRIPTION
Package source is now a class parameter, rather than an explicit lookup.
Add username and password for fetching sources (needed for nexus).