### PR TITLE
Release 3.8.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,23 @@ All notable changes to this project will be documented in this file.
 Each new release typically also includes the latest modulesync defaults.
 These should not affect the functionality of the module.
 
+## [v3.8.1](https://github.com/lsst-it/puppet-ccs_hcu/tree/v3.8.1) (2025-09-12)
+
+[Full Changelog](https://github.com/lsst-it/puppet-ccs_hcu/compare/v3.8.1...v3.8.1)
+
+**Fixed bugs:**
+
+- \(metadata.json\) Fix version of module [\#60](https://github.com/lsst-it/puppet-ccs_hcu/pull/60) ([badenerb](https://github.com/badenerb))
+
+## [v3.8.1](https://github.com/lsst-it/puppet-ccs_hcu/tree/v3.8.1) (2025-07-24)
+
+[Full Changelog](https://github.com/lsst-it/puppet-ccs_hcu/compare/v3.8.0...v3.8.1)
+
+**Implemented enhancements:**
+
+- \(metadata.json\) bump puppet archive to include 8.x.x [\#59](https://github.com/lsst-it/puppet-ccs_hcu/pull/59) ([badenerb](https://github.com/badenerb))
+- Update dependency voxpupuli-test to v11 [\#58](https://github.com/lsst-it/puppet-ccs_hcu/pull/58) ([renovate[bot]](https://github.com/apps/renovate))
+
 ## [v3.8.0](https://github.com/lsst-it/puppet-ccs_hcu/tree/v3.8.0) (2025-04-10)
 
 [Full Changelog](https://github.com/lsst-it/puppet-ccs_hcu/compare/v3.7.1...v3.8.0)


### PR DESCRIPTION
Automated release-prep through https://github.com/voxpupuli/gha-puppet/ from commit 60f0a70e24f496692bbae4c3c35901a85427a41d.
Checkout the [module release instructions](https://voxpupuli.org/docs/releasing_version/).